### PR TITLE
Fixed a 'u is null' multipipe error.

### DIFF
--- a/Source/Pipe/PipeMulti.js
+++ b/Source/Pipe/PipeMulti.js
@@ -59,11 +59,13 @@ APE.PipeMulti = new Class({
 	delUser: function(pubid) {
 		var u = this.users.get(pubid);
 		this.users.erase(pubid);
-		u.pipes.erase(this.pipe.pubid)
-		if (u.pipes.getLength() == 0) {
-			this.ape.users.erase(u.pubid);
+		if(u) {
+			u.pipes.erase(this.pipe.pubid)
+			if (u.pipes.getLength() == 0) {
+				this.ape.users.erase(u.pubid);
+			}
+			this.fireGlobalEvent('userLeft', [u, this]);
 		}
-		this.fireGlobalEvent('userLeft', [u, this]);
 		return u;
 	},
 


### PR DESCRIPTION
Fix error 'u is null' when trying to delete a user from multipipe. We were getting this error very occasionally, so I added a simple if u defined check.
